### PR TITLE
Use oscommerce pattern correctly to print <script>

### DIFF
--- a/catalog/includes/modules/header_tags/ht_pagantis.php
+++ b/catalog/includes/modules/header_tags/ht_pagantis.php
@@ -82,8 +82,9 @@ class ht_pagantis {
      */
     function execute()
     {
-        global $order;
+        global $order, $oscTemplate;
 
+        ob_start();
         $productId = $GLOBALS["HTTP_GET_VARS"]["products_id"];
         $checkoutPage = strpos($_SERVER[REQUEST_URI], "checkout_payment.php") > 0;
 
@@ -234,6 +235,7 @@ class ht_pagantis {
                 echo '</script>'. PHP_EOL;
             }
         }
+      $oscTemplate->addBlock(ob_get_clean(), $this->group);
     }
 
     /**


### PR DESCRIPTION
<script> tags are being printed before <html> tag, because the code uses echo calls. Oscommerce offers a buffered channel to print header tags output. I have corrected the code using it.